### PR TITLE
Expose Option: ignorePackageArtifact

### DIFF
--- a/src/config/commandOptions.js
+++ b/src/config/commandOptions.js
@@ -112,4 +112,7 @@ export default {
   dockerNetwork: {
     usage: 'The network that the Docker container will connect to',
   },
+  ignorePackageArtifact: {
+    usage: 'Ignores package artifact config in the serverless.yml when running',
+  },
 }

--- a/src/config/defaultOptions.js
+++ b/src/config/defaultOptions.js
@@ -18,6 +18,7 @@ export default {
   host: 'localhost',
   httpPort: 3000,
   httpsProtocol: '',
+  ignorePackageArtifact: false,
   lambdaPort: 3002,
   layersDir: null,
   noAuth: false,

--- a/src/lambda/LambdaFunction.js
+++ b/src/lambda/LambdaFunction.js
@@ -32,6 +32,7 @@ export default class LambdaFunction {
   #lambdaContext = null
   #lambdaDir = null
   #memorySize = null
+  #options = null
   #region = null
   #runtime = null
   #timeout = null
@@ -70,6 +71,7 @@ export default class LambdaFunction {
     this.#functionKey = functionKey
     this.#functionName = name
     this.#memorySize = memorySize
+    this.#options = options
     this.#region = provider.region
     this.#runtime = runtime
     this.#timeout = timeout
@@ -82,8 +84,10 @@ export default class LambdaFunction {
       handler,
     )
 
-    this.#artifact = functionDefinition.package?.artifact
-    if (!this.#artifact) {
+    this.#artifact =
+      !this.#options.ignorePackageArtifact &&
+      functionDefinition.package?.artifact
+    if (!this.#options.ignorePackageArtifact && !this.#artifact) {
       this.#artifact = service.package?.artifact
     }
     if (this.#artifact) {
@@ -238,7 +242,9 @@ export default class LambdaFunction {
   }
 
   async _initialize() {
-    await this._extractArtifact()
+    if (!this.#options.ignorePackageArtifact) {
+      await this._extractArtifact()
+    }
     this.#initialized = true
   }
 


### PR DESCRIPTION
## Feature Request

For teams not yet ready to use the package artifact as part of their development routine, would like to have a way to disable using the package artifact defined in the serverless.yml by using an custom option available to the serverless-offline plugin.

**Sample Code**

- file: serverless.yml

```yaml
service: my-service

plugins:
  - serverless-offline

custom:
  serverless-offline:
    ignorePackageArtifact: true

provider:
  runtime: nodejs12.x
  stage: dev

functions:
  hello:
    events:
      - http:
          method: get
          path: hello
    handler: handler.hello
```

- file: handler.js

```js
'use strict'

const { stringify } = JSON

exports.hello = async function hello() {
  return {
    body: stringify({ foo: 'bar' }),
    statusCode: 200,
  }
}
```

**Expected behavior/code**

It should not attempt to use or extract the package artifact defined in the serverless yaml and instead run the code in src.